### PR TITLE
Update README intro and site title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Vue 3 + TypeScript + Vite
+# E Tobi Portfolio
 
-This template should help get you started developing with Vue 3 and TypeScript in Vite. The template uses Vue 3 `<script setup>` SFCs, check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
+This project showcases the work of E Tobi. It is built with Vue 3 and TypeScript using Vite. The application uses Vue 3 `<script setup>` SFCs; see the [script setup docs](https://vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
 
 Learn more about the recommended Project Setup and IDE Support in the [Vue Docs TypeScript Guide](https://vuejs.org/guide/typescript/overview.html#project-setup).

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + Vue + TS</title>
+    <title>E Tobi Portfolio</title>
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   </head>
   <body>


### PR DESCRIPTION
## Summary
- improve README intro to describe the project
- change Vue doc link to script setup API page
- update index.html title tag for the project

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853fb45fe3c83308cd44da1ec188eba

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Update the README introduction to describe the project as E Tobi's portfolio and change the site title in `index.html` to "E Tobi Portfolio".

### Why are these changes being made?
These changes were made to reflect the purpose of the project more accurately, transitioning from a template description to a specific portfolio representation, and ensure consistency between the README and the site's title.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->